### PR TITLE
Adds a check to fractional land cover data

### DIFF
--- a/82x1_sparse_grid/82x1_sparse_grid.cfg
+++ b/82x1_sparse_grid/82x1_sparse_grid.cfg
@@ -40,7 +40,7 @@ site_latlon_filename 82x1_sparse_grid/82x1_sparse_grid_latlon.txt
 %
 % Note: Determine the default CLM surface dataset for a given CLM tag by creating
 %       a CESM case for a global grid + desired compset, and look at the
-$       fsurdat entry in CaseDocs/lnd_in file.
+%       fsurdat entry in CaseDocs/lnd_in file.
 %
 clm_gridded_surfdata_filename clm-netcdf/surfdata_1.9x2.5_simyr2000_c141219.nc
 
@@ -84,3 +84,15 @@ dlon 1
 %
 lon_min 0
 lon_max 360
+
+%
+% Optional flag to override the fractional cover of global gridded dataset
+% by setting:
+% PCT_NATVEG = 1
+% PCT_CROP   = 0
+% PCT_WETLAND= 0
+% PCT_LAKE   = 0
+% PCT_GLACIER= 0
+% PCT_URBAN  = 0
+
+set_natural_veg_frac_to_one   1

--- a/CLM45SparseGridDriver_modified.m
+++ b/CLM45SparseGridDriver_modified.m
@@ -23,6 +23,8 @@
 % +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 function [fsurdat, fdomain] = CLM45SparseGridDriver(cfg_filename)
 
+clc;
+
 disp('1) Reading configuration file')
 cfg = ReadConfigurationFile(cfg_filename);
 
@@ -36,8 +38,7 @@ disp('4) Creating CLM surface dataset')
 fsurdat = CreateCLMUgridSurfdatForCLM45(lat, lon, ...
                               cfg.clm_gridded_surfdata_filename, ...
                               cfg.out_netcdf_dir, ...
-                              cfg.clm_usrdat_name, ...
-                              cfg.set_natural_veg_frac_to_one);
+                              cfg.clm_usrdat_name);
 
 disp('5) Creating CLM domain')
 fdomain = CreateCLMUgridDomainForCLM45(lat, lon, ...

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2018, Gautam Bisht
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/PerformFractionCoverCheck.m
+++ b/PerformFractionCoverCheck.m
@@ -1,0 +1,51 @@
+% +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+% Performs checks on fractional cover.
+%
+% INPUT:
+%       varname                = name of the netcdf variable
+%       data                   = data values for the sparse grid
+%       set_frac_natveg_to_one = Flag to override default fractional cover
+%                                by setting PCT_NATVEG = 1 and all other
+%                                fractional covers to 0
+%
+% Gautam Bisht (gbisht@lbl.gov)
+% 02-27-2018
+% +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+function data = PerformFractionCoverCheck(varname, data, set_frac_natveg_to_one)
+
+switch varname
+    case {'PCT_URBAN'}        
+        if (set_frac_natveg_to_one)
+            data = data * 0;
+        elseif (max(sum(data,2) > 0))
+            disp(' ')
+            disp(['Warning: ' varname ' is not 0. for all grids' ])
+            disp('         If you wish to create surface dataset')
+            disp('         with only natural vegetation, set')
+            disp('         set_frac_natveg_to_one = 1 in CFG file')
+            disp(' ')
+        end
+        
+    case {'PCT_CROP','PCT_WETLAND','PCT_LAKE','PCT_GLACIER'}
+        if (set_frac_natveg_to_one)
+            data = data * 0;
+        elseif (max(data) > 0)
+            disp(' ')
+            disp(['Warning: ' varname ' is not 0. for all grids' ])
+            disp('         If you wish to create surface dataset')
+            disp('         with only natural vegetation, set')
+            disp('         set_frac_natveg_to_one = 1 in CFG file')
+            disp(' ')
+        end
+    case {'PCT_NATVEG'}
+        if (set_frac_natveg_to_one)
+            data = data*0 + 100;
+        elseif (min(data) < 100)
+            disp(' ')
+            disp(['Warning: ' varname ' is not 100. for all grids' ])
+            disp('         If you wish to create surface dataset')
+            disp('         with only natural vegetation, set')
+            disp('         set_frac_natveg_to_one = 1 in CFG file')
+            disp(' ')
+        end
+end

--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ svn export https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata/lnd/clm2/surf
 5) Creating CLM domain
   domain: 82x1_sparse_grid/domain_82x1_sparse_grid_c180227.nc
 ```
+
+## License
+
+[BSD-3](https://github.com/bishtgautam/matlab-script-for-clm-sparse-grid/License.txt)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,41 @@
 
-To run an example, do the following::
+## Running the code
 
-1) Download surface data and domain data
+1. Download the code
+
+```
+git clone https://github.com/bishtgautam/matlab-script-for-clm-sparse-grid
+```
+
+
+2. Download surface data and domain data to run the 82x1_sparse_grid example
+
 ```
 mkdir clm-netcdf
 svn export https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata/share/domains/domain.clm/domain.lnd.fv1.9x2.5_USGS.110713.nc ./clm-netcdf
 svn export https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata/lnd/clm2/surfdata_map/surfdata_1.9x2.5_simyr2000_c141219.nc ./clm-netcdf
 ```
 
-2) Run the example provied in 82x1_sparse_grid in MATLAB
+3. Launch MATLAB
+
+```matlab
+<MATLAB_INSTALLATION_DIR>/bin/matlab -nodesktop
 ```
->>CLM45SparseGridDriver('82x1_sparse_grid/82x1_sparse_grid.cfg')
+
+4. Run the example
+
+```matlab
+>> cd <matlab-script-for-clm-sparse-grid>
+>> CLM45SparseGridDriver('82x1_sparse_grid/82x1_sparse_grid.cfg');
+1) Reading configuration file
+2) Reading latitude/longitude @ cell centroid
+3) Computing latitude/longitude @ cell vertex
+4) Creating CLM surface dataset
+  surface_dataset: 82x1_sparse_grid/surfdata_82x1_sparse_grid_c180227.nc
+  WARNING: Site with (lat,lon) = (43.730000,288.750000) has more than one cells that are equidistant.
+           Picking the first closest grid cell.
+		Possible grid cells: 44.526316 287.500000
+		Possible grid cells: 44.526316 290.000000
+5) Creating CLM domain
+  domain: 82x1_sparse_grid/domain_82x1_sparse_grid_c180227.nc
 ```

--- a/ReadConfigurationFile.m
+++ b/ReadConfigurationFile.m
@@ -19,6 +19,7 @@ cfg.dlat                           = 0;
 cfg.dlon                           = 0;
 cfg.lon_min                        = -999;
 cfg.lon_max                        = -999;
+cfg.set_natural_veg_frac_to_one    = 0;
 
 % Read the file
 fid = fopen (fname,'r');
@@ -54,6 +55,8 @@ while ~feof(fid)
                     cfg.lon_min = str2double(tmp_string{2});                    
                 case 'lon_max'
                     cfg.lon_max = str2double(tmp_string{2});
+                case 'set_natural_veg_frac_to_one'
+                    cfg.set_natural_veg_frac_to_one = str2double(tmp_string{2});
                 otherwise
                     error(['Unknown variable: ' tmp_string{1}])
             end
@@ -109,7 +112,6 @@ if ~(cfg.lon_min == 0 && cfg.lon_max == 360)
     error(['Stopping because lon_min and lon_max not equal to 0 and 360.'])
 end
 
-
 loc = find(cfg.site_latlon_filename == '/');
 if (~isempty(loc))
     cfg.out_netcdf_dir = cfg.site_latlon_filename(1:loc(end)-1);
@@ -117,5 +119,11 @@ else
     cfg.out_netcdf_dir = './';
 end
 
+switch cfg.set_natural_veg_frac_to_one
+    case {0,1}
+    otherwise
+        disp('Valid values for set_natural_veg_frac_to_one are 0 or 1')
+        error(['Stopping because set_natural_veg_frac_to_one is defined as ' num2str(cfg.set_natural_veg_frac_to_one)])
+end
 
 


### PR DESCRIPTION
Introduces a new card `set_natural_veg_frac_to_one` to CFG that can
override the fractional cover of global gridded dataset
by setting following values in the sparse surface dataset:
- PCT_NATVEG = 1, and
- PCT_CROP   = 0, and
- PCT_WETLAND= 0, and
- PCT_LAKE   = 0, and
- PCT_GLACIER= 0, and
- PCT_URBAN  = 0

Fixes #1